### PR TITLE
Refactor to not use `slog_scope`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ publicsuffix = "1.3"
 lazy_static = "0.2"
 parking_lot = "0.3"
 slog = "1.2"
-slog-scope = "0.2"
 app_dirs = "1.1"
 
 [dev-dependencies]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,7 @@ extern crate slog_term;
 use std::thread;
 use std::time::Duration;
 
-use {init, get, set_logger};
+use {init, get};
 use publicsuffix::LIST_URL;
 use slog::{Logger, DrainExt};
 use self::rspec::context::rdescribe;
@@ -23,7 +23,8 @@ fn cache_behaviour() {
     });
 
     rdescribe("initialised cache", |ctx| {
-        init(LIST_URL, Duration::from_secs(20)).unwrap();
+        let log = Logger::root(slog_term::streamer().build().fuse(), o!("test" => "updating"));
+        init(LIST_URL, Duration::from_secs(20), log).unwrap();
 
         ctx.it("should have ICANN domains", || {
             assert!(!get().icann().is_empty());
@@ -36,8 +37,6 @@ fn cache_behaviour() {
         });
 
         ctx.it("should download a new list at the given interval", || {
-            let log = Logger::root(slog_term::streamer().build().fuse(), o!("test" => "updating"));
-            set_logger(&log);
             thread::sleep(Duration::from_secs(30));
             assert!(!get().all().is_empty());
             pass!()


### PR DESCRIPTION
Hi, author of slog here.

First of all, thanks for using slog. I sometimes visit reverse dependencies of it, and checks what's going on. 

This patch changes the API (breaking change) to take the `Logger` during `init` and most importantly not use `slog_scope` to set the global handler.

Generally accepting `Logger` manually gives the user of a library maximum of flexibility. If the app is using `slog_scope` it can always pass `slog_scope::logger()`, if not it can pass the manual logger it has. Generally libraries should not be using `slog_scope` (IMO) as it gets in the way of the application that are using `slog_scope`, might want to set their own handler etc.
