### PR TITLE
Remove needless specific release from travis file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 
 rust:
-  - 1.25.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
There's no reason for the `1.25.0` line in the Travis file to be there, so it should be removed, especially as it's extremely out of date.