### PR TITLE
Reject email with empty local part.

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -16,7 +16,7 @@ lazy_static! {
         // the pattern to match
         let quoted = r#"["(),\\:;<>@\[\]. ]"#;
         // combined regex
-        let combined = format!(r#"({}*{}*)"#, global, non_ascii);
+        let combined = format!(r#"({}+|{}+)"#, global, non_ascii);
 
         let exprs = vec![
             // can be any combination of allowed characters

--- a/src/host.rs
+++ b/src/host.rs
@@ -13,14 +13,14 @@ impl FromStr for Host {
         if let Ok(domain) = DomainName::from_str(host) {
             return Ok(Host::Domain(domain));
         }
-        if host.starts_with("[") 
+        if host.starts_with("[")
             && !host.starts_with("[[")
                 && host.ends_with("]")
                 && !host.ends_with("]]")
                 {
                     host = host
-                        .trim_left_matches("[")
-                        .trim_right_matches("]");
+                        .trim_start_matches("[")
+                        .trim_end_matches("]");
                 };
         if let Ok(ip) = IpAddr::from_str(host) {
             return Ok(Host::Ip(ip));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,7 +33,7 @@ pub fn parse_domain(input: &str) -> Result<String, String> {
         } else {
             &punycode
         };
-        let mut labels = punycode.rsplit('.');
+        let labels = punycode.rsplit('.');
         // check total lengths
         if punycode.len() > MAX_DOMAIN_LEN || labels.clone().count() > MAX_LABELS_COUNT {
             false
@@ -46,7 +46,7 @@ pub fn parse_domain(input: &str) -> Result<String, String> {
                 let check_labels = || {
                     for label in labels {
                         if label.trim().is_empty() { return false; }
-                        let mut chars = label.chars();
+                        let chars = label.chars();
                         let last = label.len() - 1;
                         for (i, c) in chars.enumerate() {
                             if ((i == 0 || i == last) && !c.is_alphanumeric()) || (c != '-' && !c.is_alphanumeric()) {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -241,6 +241,7 @@ fn addr_parsing() {
                 "john.doe@example..com",
                 " prettyandsimple@example.com",
                 "prettyandsimple@example.com ",
+                "@example.com",
             ];
             for email in emails {
                 assert!(Email::from_str(email).is_err());


### PR DESCRIPTION
Hi,
i noticed that email addresses with an empty local part were evaluated as correct addresses, e.g. `@example.com`. This should not be the case. I have modified the regex, so at least one character has to be present.